### PR TITLE
add optional to disable audio recycle

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -39,19 +39,25 @@ let recycleAudio = function (audio) {
     if (!audio._shouldRecycleOnEnded) {
         return;
     }
-    audio._finishCallback = null;
-    audio.off('ended');
-    audio.off('stop');
-    audio.src = null;
-    // In case repeatly recycle audio
-    if (!_audioPool.includes(audio)) {
-        if (_audioPool.length < 32) {
-            _audioPool.push(audio);
-        }
-        else {
-            audio.destroy();
+    // Some browser does not support recycle usage of audio
+    if (!!window.DISABLE_RECYCLE_AUDIO) {
+        audio.destroy();
+    } else{
+        audio._finishCallback = null;
+        audio.off('ended');
+        audio.off('stop');
+        audio.src = null;
+        // In case repeatly recycle audio
+        if (!_audioPool.includes(audio)) {
+            if (_audioPool.length < 32) {
+                _audioPool.push(audio);
+            }
+            else {
+                audio.destroy();
+            }
         }
     }
+
     audio._shouldRecycleOnEnded = false;
 };
 


### PR DESCRIPTION
In my embedded Linux, the browser might crash after playing audio.

It seems like some bugs towards the audio reusing in the browser. So I add some workaround to disable the recycling.

## How to use
* modify the engine with [change](https://github.com/mgwn/engine/pull/1/files) in this PR ([doc: Engine Customization Workflow](https://docs.cocos.com/creator/manual/en/advanced-topics/engine-customization.html))
* add ```window.DISABLE_RECYCLE_AUDIO = true;``` before loading audio. (e.g. in the `setting.js`).

